### PR TITLE
Move issue tracker to Github

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -20,7 +20,11 @@ location = build
 copy = README.md
 [Repository]
 [MetaResources]
-homepage=http://timetracker.plix.at
+homepage        = http://timetracker.plix.at
+bugtracker.web  = https://github.com/domm/App-TimeTracker-RT/issues
+repository.url  = git@github.com:domm/App-TimeTracker-RT.git
+repository.web  = https://github.com/domm/App-TimeTracker-RT
+repository.type = git
 [CheckChangeLog]
 [Manifest]
 [TestRelease]


### PR DESCRIPTION
With a link to the repository for good measure.

With the [possible sunsetting of rt.cpan.org](https://log.perl.org/2020/12/rtcpanorg-sunset.html) it seems a good idea to move issue tracking somewhere else.  While it's entirely possible that rt.cpan.org will find a new home (that actually looks fairly likely) and keep running, with the code hosted on GitHub, the issue tracker being there too makes sense.

Note that I got this repo as my pullrequest.club assignment this month and thought this would be a useful change since I didn't see issues in either place yet.